### PR TITLE
Interpret puppetdb_enabled="false" (string) as disabled

### DIFF
--- a/app/models/puppetdb_foreman/host_extensions.rb
+++ b/app/models/puppetdb_foreman/host_extensions.rb
@@ -24,7 +24,7 @@ module PuppetdbForeman
         logger.debug "Deactivating host #{name} in Puppetdb"
         return false unless configured?
 
-        if Setting[:puppetdb_enabled]
+        if enabled?
           begin
             uri = URI.parse(Setting[:puppetdb_address])
             req = Net::HTTP::Post.new(uri.path)
@@ -55,10 +55,14 @@ module PuppetdbForeman
       private
 
       def configured?
-        if Setting[:puppetdb_enabled] && Setting[:puppetdb_address].blank?
+        if enabled? && Setting[:puppetdb_address].blank?
           errors.add(:base, _("PuppetDB plugin is enabled but not configured. Please configure it before trying to delete a host."))
         end
         errors.empty?
+      end
+
+      def enabled?
+        [true, 'true'].include? Setting[:puppetdb_enabled]
       end
     end
   end

--- a/app/models/setting/puppetdb.rb
+++ b/app/models/setting/puppetdb.rb
@@ -7,7 +7,7 @@ class Setting::Puppetdb < ::Setting
       default_address = SETTINGS[:puppetdb][:address]
     end
 
-    default_enabled ||= 'false'
+    default_enabled = false if default_enabled.nil?
     default_address ||= 'https://puppetdb:8081/v2/commands'
 
     Setting.transaction do


### PR DESCRIPTION
The default value of the puppetdb_enabled setting had been "false" (string)
causing the destroy handler to think it was always enabled, which would then
fail.  The default has been changed to a boolean, but also handle strings for
existing installations.

I could add DB migrations, but figured it's overkill.
