### PR TITLE
 Adding :deactivate_host on after_build hook as well.

### DIFF
--- a/app/models/puppetdb_foreman/host_extensions.rb
+++ b/app/models/puppetdb_foreman/host_extensions.rb
@@ -19,6 +19,7 @@ module PuppetdbForeman
     extend ActiveSupport::Concern
     included do
       before_destroy :deactivate_host
+      after_build :deactivate_host
 
       def deactivate_host
         logger.debug "Deactivating host #{name} in Puppetdb"


### PR DESCRIPTION
We ran into issues on rebuild when using exported resources.
It makes sense to deactivate hosts in PuppetDB when they are rebuilt?
