### PR TITLE
Add error types for can't proxy PuppetDB Dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # puppetdb\_foreman
 
-This is a [Foreman](http://theforeman.org) to interact with [PuppetDB](https://docs.puppetlabs.com/puppetdb/index.html).
+This is a [Foreman](http://theforeman.org) plugin to interact with [PuppetDB](https://docs.puppetlabs.com/puppetdb/index.html).
 
 It does the following:
 
@@ -38,14 +38,14 @@ puppetdb_foreman uses [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.
 
 # Usage:
 
-Go to Administer > Settings > PuppetDB and set `puppetdb_address` with your PuppetDB address, `puppetdb_dashboard` (optional) to proxy the dashboard, `puppetdb_enabled` to either true or false if you want to enable or disable PuppetDB integration. Obviously you will need a PuppetDB instance at the address you provide.
+Go to Administer > Settings > PuppetDB and set `puppetdb_address` with your PuppetDB address, `puppetdb_dashboard_address` (optional) to proxy the dashboard, `puppetdb_enabled` to either true or false if you want to enable or disable PuppetDB integration. Obviously you will need a PuppetDB instance at the address you provide.
 
 Alternatively you can put your settings in `config/settings.yaml`. Please keep in mind these will be overwritten if changed in the application, and if the application is rebooted, YAML rules will overwrite again your manually changed settings. Hence passing your settings in this format is discouraged, but allowed.
 ```yaml
 :puppetdb:
   :enabled: true
   :address: 'https://puppetdb:8081/v2/commands'
-  :dashboard_address: 'https://puppetdb:8080/'
+  :dashboard_address: 'http://puppetdb:8080/dashboard'
 ```
 
 You can find the dashboard under Monitor > PuppetDB dashboard. Only administrators and users with a role `view_puppetdb_dashboard` will be able to access it. Aside from convenience, the PuppetDB dashboard cannot be served over HTTPS, you can restrict your dashboard requests to only Foreman boxes and serve it securely to your users through HTTPS in Foreman.

--- a/app/controllers/puppetdb_foreman/puppetdb_controller.rb
+++ b/app/controllers/puppetdb_foreman/puppetdb_controller.rb
@@ -12,6 +12,13 @@ module PuppetdbForeman
         result = Net::HTTP.get_response(uri.host, puppetdb_url, uri.port)
         render :text => result.body, :layout => layout
       rescue SocketError => error
+        @proxy_error = "Problem connecting to host #{uri.host} on port #{uri.port}"
+        render :action => :error, :layout => true
+      rescue Errno::ECONNREFUSED => error
+        @proxy_error = "#{uri.host} refused our conneciton"
+        render :action => :error, :layout => true
+      rescue EOFError => error
+        @proxy_error = "Don't use ssl (https)"
         render :action => :error, :layout => true
       end
     end

--- a/app/views/puppetdb_foreman/puppetdb/error.html.erb
+++ b/app/views/puppetdb_foreman/puppetdb/error.html.erb
@@ -1,4 +1,4 @@
 <div class="alert alert-block alert-warning">
-  <p><strong><%= _("Notice") %></strong> <%= _("Error Proxying PuppetDB Dashboard") %></p>
+  <p><strong><%= _("Notice") %></strong> <%= _("Error Proxying PuppetDB Dashboard: #{@proxy_error}") %></p>
   <p><%= _("Maybe you need to set") %> <%= link_to(_("puppetdb_dashboard_address"), settings_path(:search => 'puppetdb_dashboard_address')) %> <%= _("in Settings") %></p>
 </div>

--- a/puppetdb_foreman.gemspec
+++ b/puppetdb_foreman.gemspec
@@ -1,7 +1,7 @@
 require 'rake'
 Gem::Specification.new do |s|
   s.name        = 'puppetdb_foreman'
-  s.version     = '0.1.1'
+  s.version     = '0.1.2'
   s.date        = '2014-10-11'
   s.license     = 'Apache-2.0'
   s.summary     = 'This is a Foreman plugin to interact with PuppetDB.'


### PR DESCRIPTION
I found some cases that cause a 500 page with malformed puppetdb_dashboard_address.
This fixes that and includes more helpful error messages.

Also, some README fixes.
