### PR TITLE
Plugin compatibility changes for foreman 1.10.0

### DIFF
--- a/app/models/puppetdb_foreman/host_extensions.rb
+++ b/app/models/puppetdb_foreman/host_extensions.rb
@@ -7,9 +7,9 @@ module PuppetdbForeman
 
       def deactivate_host
         logger.debug "Deactivating host #{name} in Puppetdb"
-        return false unless configured?
+        return false unless puppetdb_configured?
 
-        if enabled?
+        if puppetdb_enabled?
           begin
             uri = URI.parse(Setting[:puppetdb_address])
             req = Net::HTTP::Post.new(uri.path)
@@ -39,14 +39,14 @@ module PuppetdbForeman
 
       private
 
-      def configured?
-        if enabled? && Setting[:puppetdb_address].blank?
+      def puppetdb_configured?
+        if puppetdb_enabled? && Setting[:puppetdb_address].blank?
           errors.add(:base, _("PuppetDB plugin is enabled but not configured. Please configure it before trying to delete a host."))
         end
         errors.empty?
       end
 
-      def enabled?
+      def puppetdb_enabled?
         [true, 'true'].include? Setting[:puppetdb_enabled]
       end
     end

--- a/lib/puppetdb_foreman/engine.rb
+++ b/lib/puppetdb_foreman/engine.rb
@@ -20,13 +20,7 @@ module PuppetdbForeman
     end
 
     config.to_prepare do
-      if SETTINGS[:version].to_s.to_f >= 1.2
-        # Foreman 1.2
-        Host::Managed.send :include, PuppetdbForeman::HostExtensions
-      else
-        # Foreman < 1.2
-        Host.send :include, PuppetdbForeman::HostExtensions
-      end
+      Host::Managed.send :include, PuppetdbForeman::HostExtensions
     end
   end
 end


### PR DESCRIPTION
- remove broken version comparison against 1.2
- prefix enabled? and configured? method with plugin name as enabled? is
now used in foreman app/models/host_status/configuration_status.rb in
out_of_sync?