### PR TITLE
Modified codes to support PuppetDB 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ puppetdb_foreman uses [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.
 Go to Administer > Settings > PuppetDB and set `puppetdb_address` with your PuppetDB address, `puppetdb_dashboard_address` (optional) to proxy the dashboard, `puppetdb_enabled` to either true or false if you want to enable or disable PuppetDB integration. Obviously you will need a PuppetDB instance at the address you provide.
 
 Alternatively you can put your settings in `config/settings.yaml`. Please keep in mind these will be overwritten if changed in the application, and if the application is rebooted, YAML rules will overwrite again your manually changed settings. Hence passing your settings in this format is discouraged, but allowed.
+
+for PuppetDB 4
 ```yaml
 :puppetdb:
   :enabled: true
-  :address: 'https://puppetdb:8081/v2/commands'
-  :dashboard_address: 'http://puppetdb:8080/dashboard'
+  :address: 'https://puppetdb:8081/pdb/cmd/v1'
+  :dashboard_address: 'http://puppetdb:8080/pdb/dashboard'
+  :puppetdb_ssl_ca_file: '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
+  :puppetdb_ssl_certificate: '/etc/puppetlabs/puppet/ssl/certs/FQDN.pem'
+  :puppetdb_ssl_private_key: '/etc/puppetlabs/puppet/ssl/private_keys/FQDN.pem'
 ```
 
 You can find the dashboard under Monitor > PuppetDB dashboard. Only administrators and users with a role `view_puppetdb_dashboard` will be able to access it. Aside from convenience, the PuppetDB dashboard cannot be served over HTTPS, you can restrict your dashboard requests to only Foreman boxes and serve it securely to your users through HTTPS in Foreman.

--- a/app/models/setting/puppetdb.rb
+++ b/app/models/setting/puppetdb.rb
@@ -6,11 +6,17 @@ class Setting::Puppetdb < ::Setting
       default_enabled = SETTINGS[:puppetdb][:enabled]
       default_address = SETTINGS[:puppetdb][:address]
       default_dashboard_address = SETTINGS[:puppetdb][:dashboard_address]
+      default_ssl_ca_file= SETTINGS[:puppetdb][:ssl_ca_file]
+      default_ssl_certificate = SETTINGS[:puppetdb][:ssl_certificate]
+      default_ssl_private_key = SETTINGS[:puppetdb][:ssl_private_key]
     end
 
     default_enabled = false if default_enabled.nil?
-    default_address ||= 'https://puppetdb:8081/v2/commands'
-    default_dashboard_address ||= 'http://puppetdb:8080/dashboard'
+    default_address ||= 'https://puppetdb:8081/pdb/cmd/v1'
+    default_dashboard_address ||= 'http://puppetdb:8080/pdb/dashboard'
+    default_ssl_ca_file ||= "#{SETTINGS[:ssl_ca_file]}"
+    default_ssl_certificate ||= "#{SETTINGS[:ssl_certificate]}"
+    default_ssl_private_key ||= "#{SETTINGS[:ssl_priv_key]}"
 
     Setting.transaction do
       [
@@ -27,6 +33,24 @@ class Setting::Puppetdb < ::Setting
     Setting.transaction do
       [
         self.set('puppetdb_dashboard_address', _('Foreman will proxy PuppetDB Performance Dashboard requests to this address'), default_dashboard_address)
+      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
+    end
+
+    Setting.transaction do
+      [
+        self.set('puppetdb_ssl_ca_file', _('Foreman will send PuppetDB requests with this CA file'), default_ssl_ca_file)
+      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
+    end
+
+    Setting.transaction do
+      [
+        self.set('puppetdb_ssl_certificate', _('Foreman will send PuppetDB requests with this certificate file'), default_ssl_certificate)
+      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
+    end
+
+    Setting.transaction do
+      [
+        self.set('puppetdb_ssl_private_key', _('Foreman will send PuppetDB requests with this key file'), default_ssl_private_key)
       ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
     end
   end


### PR DESCRIPTION
As we know PuppetDB 2 is EOL quite a long time ago.
but this plugin does support this version.

so I changed this kind of things 
- Uses new API (https://docs.puppet.com/puppetdb/4.3/api/command/v1/commands.html)
- Can change SSL certificate which are used for communicating with PuppetDB from the Puppetdb setting section.

Please approve this pull request