### PR TITLE
puppetdb uses host queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,42 @@
+AllCops:
+  TargetRubyVersion: 2.0
+
+Rails:
+  Enabled: true
+
+# Don't enforce documentation
+Style/Documentation:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 20
+
+Metrics/LineLength:
+  Max: 180
+  Exclude:
+    - 'puppetdb_foreman.gemspec'
+
+Style/Next:
+  Enabled: false
+
+# Support both ruby19 and hash_rockets
+Style/HashSyntax:
+  Enabled: false
+
+# SupportedStyles: format, sprintf, percent
+Style/FormatString:
+  Enabled: false
+
+Style/MethodName:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 25
+
+Rails/Date:
+  Exclude:
+    - 'puppetdb_foreman.gemspec'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,47 @@
+#!/usr/bin/env rake
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+begin
+  require 'rdoc/task'
+rescue LoadError
+  require 'rdoc/rdoc'
+  require 'rake/rdoctask'
+  RDoc::Task = Rake::RDocTask
+end
+
+RDoc::Task.new(:rdoc) do |rdoc|
+  rdoc.rdoc_dir = 'rdoc'
+  rdoc.title    = 'PuppetdbForeman'
+  rdoc.options << '--line-numbers'
+  rdoc.rdoc_files.include('README.rdoc')
+  rdoc.rdoc_files.include('lib/**/*.rb')
+end
+
+APP_RAKEFILE = File.expand_path('../test/dummy/Rakefile', __FILE__)
+
+Bundler::GemHelper.install_tasks
+
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'lib'
+  t.libs << 'test'
+  t.pattern = 'test/**/*_test.rb'
+  t.verbose = false
+end
+
+task default: :test
+
+begin
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+rescue => _
+  puts 'Rubocop not loaded.'
+end
+
+task :default do
+  Rake::Task['rubocop'].execute
+end

--- a/app/models/concerns/orchestration/puppetdb.rb
+++ b/app/models/concerns/orchestration/puppetdb.rb
@@ -1,0 +1,27 @@
+module Orchestration
+  module Puppetdb
+    extend ActiveSupport::Concern
+
+    included do
+      before_destroy :queue_puppetdb_destroy
+    end
+
+    protected
+
+    def queue_puppetdb_destroy
+      return unless ::Puppetdb.ready? && errors.empty?
+      queue.create(:name   => _('Deactivating node %s in PuppetDB') % self, :priority => 60,
+                   :action => [self, :delPuppetdb])
+    end
+
+    def delPuppetdb
+      Rails.logger.info "Deactivating node in PuppetDB: #{name}"
+      ::Puppetdb.client.deactivate_node(name)
+    rescue => e
+      failure _("Failed to deactiate node %{name} in PuppetDB: %{message}\n ") %
+              { :name => name, :message => e.message }, e
+    end
+
+    def setPuppetdb; end
+  end
+end

--- a/app/models/puppetdb_foreman/host_extensions.rb
+++ b/app/models/puppetdb_foreman/host_extensions.rb
@@ -2,77 +2,25 @@ module PuppetdbForeman
   module HostExtensions
     extend ActiveSupport::Concern
     included do
-      before_destroy :deactivate_host
+      include Orchestration::Puppetdb
+
       after_build :deactivate_host
+    end
 
-      def deactivate_host
-        logger.debug "Deactivating host #{name} in Puppetdb"
-        return false unless puppetdb_configured?
+    def deactivate_host
+      logger.debug "Deactivating host #{name} in PuppetDB"
+      return true unless Puppetdb.enabled?
 
-        if puppetdb_enabled?
-          begin
-            uri = URI.parse(Setting[:puppetdb_address])
-            req = Net::HTTP::Post.new(uri.path)
-            req['Accept'] = 'application/json'
-            req.content_type = 'application/json'
-
-            res             = Net::HTTP.new(uri.host, uri.port)
-            res.use_ssl     = uri.scheme == 'https'
-            if res.use_ssl?
-              if Setting[:puppetdb_ssl_ca_file]
-                res.ca_file = Setting[:puppetdb_ssl_ca_file]
-                res.verify_mode = OpenSSL::SSL::VERIFY_PEER
-              else
-                res.verify_mode = OpenSSL::SSL::VERIFY_NONE
-              end
-              if Setting[:puppetdb_ssl_certificate] &&
-                Setting[:puppetdb_ssl_private_key]
-                res.cert = OpenSSL::X509::Certificate.new(
-                  File.read(Setting[:puppetdb_ssl_certificate]))
-                res.key  = OpenSSL::PKey::RSA.new(
-                  File.read(Setting[:puppetdb_ssl_private_key]), nil)
-              end
-
-            end
-
-            if uri.path.start_with?("/pdb")
-              logger.debug "Using PuppetDB API v3"
-              req.body = {
-                 "command" => "deactivate node",
-                 "version" => 3,
-                 "payload" => {
-                   "certname" => name,
-                   "producer_timestamp" => "#{Time.now.iso8601}"
-                 }
-               }.to_json
-            else
-              logger.debug "Using PuppetDB API v1"
-              req.body = {
-                "command" => "deactivate node",
-                "version" => 1,
-                "payload" => name
-              }.to_json
-            end
-            res.start { |http| http.request(req) }
-
-          rescue => e
-            errors.add(:base, _("Could not deactivate host on PuppetDB: #{e}"))
-          end
-          errors.empty?
-        end
+      unless Puppetdb.configured?
+        errors.add(:base,
+                   _('PuppetDB plugin is enabled but not configured. Please configure it before trying to delete a host.'))
       end
 
-      private
-
-      def puppetdb_configured?
-        if puppetdb_enabled? && Setting[:puppetdb_address].blank?
-          errors.add(:base, _("PuppetDB plugin is enabled but not configured. Please configure it before trying to delete a host."))
-        end
-        errors.empty?
-      end
-
-      def puppetdb_enabled?
-        [true, 'true'].include? Setting[:puppetdb_enabled]
+      begin
+        Puppetdb.client.deactivate_node(name)
+      rescue => e
+        errors.add(:base, _("Could not deactivate host on PuppetDB: #{e}"))
+        return false
       end
     end
   end

--- a/app/services/puppetdb.rb
+++ b/app/services/puppetdb.rb
@@ -1,0 +1,31 @@
+module Puppetdb
+  def self.client
+    options = {
+      :uri => uri,
+      :ssl_ca_file => Setting[:puppetdb_ssl_ca_file],
+      :ssl_certificate_file => Setting[:puppetdb_ssl_certificate],
+      :ssl_private_key_file => Setting[:puppetdb_ssl_private_key]
+    }
+    if uri.path.start_with?('/pdb')
+      PuppetdbClient::V3.new(options)
+    else
+      PuppetdbClient::V1.new(options)
+    end
+  end
+
+  def self.uri
+    URI.parse(Setting[:puppetdb_address])
+  end
+
+  def self.enabled?
+    [true, 'true'].include? Setting[:puppetdb_enabled]
+  end
+
+  def self.configured?
+    Setting[:puppetdb_address].present?
+  end
+
+  def self.ready?
+    enabled? && configured?
+  end
+end

--- a/app/services/puppetdb_client/base.rb
+++ b/app/services/puppetdb_client/base.rb
@@ -1,0 +1,67 @@
+module PuppetdbClient
+  class Base
+    delegate :logger, :to => :Rails
+    attr_reader :uri, :ssl_ca_file, :ssl_certificate_file, :ssl_private_key_file
+
+    def initialize(opts)
+      @uri = opts.fetch(:uri)
+      @ssl_ca_file = opts.fetch(:ssl_ca_file)
+      @ssl_certificate_file = opts.fetch(:ssl_certificate_file)
+      @ssl_private_key_file = opts.fetch(:ssl_private_key_file)
+    end
+
+    def deactivate_node(nodename)
+      post(uri.path, deactivate_node_payload(nodename))
+    end
+
+    private
+
+    def post_request(endpoint, payload)
+      req = Net::HTTP::Post.new(endpoint)
+      req['Accept'] = 'application/json'
+      req.body = payload
+      req
+    end
+
+    def post(endpoint, payload)
+      req = post_request(endpoint, payload)
+      connection.start do |http|
+        response = http.request(req)
+        response_ok?(response)
+      end
+    end
+
+    def response_ok?(response)
+      raise Foreman::Exception.new(N_('Failed to deactivate node on PuppetDB: %s'), response.body) unless response.code == '200'
+      body = JSON.parse(response.body)
+      logger.info "Submitted deactivate_node job to PuppetDB with UUID: #{body['uuid']}"
+      true
+    end
+
+    def connection
+      res             = Net::HTTP.new(uri.host, uri.port)
+      res.use_ssl     = uri.scheme == 'https'
+      if res.use_ssl?
+        if ssl_ca_file
+          res.ca_file = ssl_ca_file
+          res.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        else
+          res.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
+        if ssl_certificate_file && ssl_private_key_file
+          res.cert = ssl_certificate
+          res.key  = ssl_private_key
+        end
+      end
+      res
+    end
+
+    def ssl_certificate
+      OpenSSL::X509::Certificate.new(File.read(ssl_certificate_file))
+    end
+
+    def ssl_private_key
+      OpenSSL::PKey::RSA.new(File.read(ssl_private_key_file), nil)
+    end
+  end
+end

--- a/app/services/puppetdb_client/v1.rb
+++ b/app/services/puppetdb_client/v1.rb
@@ -1,0 +1,13 @@
+module PuppetdbClient
+  class V1 < Base
+    # The payload is expected to be the certname of a node as a serialized JSON string.
+    def deactivate_node_payload(nodename)
+      payload = {
+        'command' => 'deactivate node',
+        'version' => 1,
+        'payload' => nodename.to_json
+      }.to_json
+      'payload=' + payload
+    end
+  end
+end

--- a/app/services/puppetdb_client/v3.rb
+++ b/app/services/puppetdb_client/v3.rb
@@ -1,0 +1,29 @@
+module PuppetdbClient
+  class V3 < Base
+    def post_request(endpoint, payload)
+      req = super
+      req.content_type = 'application/json'
+      req
+    end
+
+    # The payload is formatted as a JSON map.
+    # certname: The name of the node for which the catalog was compiled.
+    # producer_timestamp: The time of command submission.
+    def deactivate_node_payload(nodename)
+      {
+        'command' => 'deactivate node',
+        'version' => 3,
+        'payload' => {
+          'certname' => nodename,
+          'producer_timestamp' => producer_timestamp
+        }
+      }.to_json
+    end
+
+    private
+
+    def producer_timestamp
+      Time.now.iso8601.to_s
+    end
+  end
+end

--- a/lib/puppetdb_foreman/engine.rb
+++ b/lib/puppetdb_foreman/engine.rb
@@ -1,19 +1,24 @@
 module PuppetdbForeman
   class Engine < ::Rails::Engine
+    engine_name 'puppetdb_foreman'
 
-    initializer 'puppetdb_foreman.load_default_settings', :before => :load_config_initializers do |app|
-      require_dependency File.expand_path("../../../app/models/setting/puppetdb.rb", __FILE__) if (Setting.table_exists? rescue(false))
+    initializer 'puppetdb_foreman.load_default_settings', :before => :load_config_initializers do |_app|
+      require_dependency File.expand_path('../../../app/models/setting/puppetdb.rb', __FILE__) if begin
+                                                                                                     Setting.table_exists?
+                                                                                                   rescue
+                                                                                                     (false)
+                                                                                                   end
     end
 
-    initializer 'puppetdb_foreman.register_plugin', :before => :finisher_hook do |app|
+    initializer 'puppetdb_foreman.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :puppetdb_foreman do
         requires_foreman '>= 1.11'
         security_block :puppetdb_foreman do
-          permission :view_puppetdb_dashboard, {:'puppetdb_foreman/puppetdb' => [:index]}
+          permission :view_puppetdb_dashboard, :'puppetdb_foreman/puppetdb' => [:index]
         end
         role 'PuppetDB Dashboard', [:view_puppetdb_dashboard]
         menu :top_menu, :puppetdb, :caption => N_('PuppetDB Dashboard'),
-                                   :url_hash => {:controller => 'puppetdb_foreman/puppetdb', :action => 'index', :puppetdb => 'puppetdb'},
+                                   :url_hash => { :controller => 'puppetdb_foreman/puppetdb', :action => 'index', :puppetdb => 'puppetdb' },
                                    :parent => :monitor_menu,
                                    :last => true
       end

--- a/lib/puppetdb_foreman/version.rb
+++ b/lib/puppetdb_foreman/version.rb
@@ -1,3 +1,3 @@
 module PuppetdbForeman
-  VERSION = '2.0.0'
+  VERSION = '2.0.0'.freeze
 end

--- a/lib/tasks/puppetdb_foreman_tasks.rake
+++ b/lib/tasks/puppetdb_foreman_tasks.rake
@@ -1,0 +1,35 @@
+# Tests
+namespace :test do
+  desc 'Test PuppetdbForeman'
+  Rake::TestTask.new(:puppetdb_foreman) do |t|
+    test_dir = File.join(File.dirname(__FILE__), '../..', 'test')
+    t.libs << ['test', test_dir]
+    t.pattern = "#{test_dir}/**/*_test.rb"
+    t.verbose = true
+    t.warning = false
+  end
+end
+
+namespace :puppetdb_foreman do
+  task :rubocop do
+    begin
+      require 'rubocop/rake_task'
+      RuboCop::RakeTask.new(:rubocop_puppetdb_foreman) do |task|
+        task.patterns = ["#{PuppetdbForeman::Engine.root}/app/**/*.rb",
+                         "#{PuppetdbForeman::Engine.root}/lib/**/*.rb",
+                         "#{PuppetdbForeman::Engine.root}/test/**/*.rb"]
+      end
+    rescue
+      puts 'Rubocop not loaded.'
+    end
+
+    Rake::Task['rubocop_puppetdb_foreman'].invoke
+  end
+end
+
+Rake::Task[:test].enhance ['test:puppetdb_foreman']
+
+load 'tasks/jenkins.rake'
+if Rake::Task.task_defined?(:'jenkins:unit')
+  Rake::Task['jenkins:unit'].enhance ['test:puppetdb_foreman', 'puppetdb_foreman:rubocop']
+end

--- a/puppetdb_foreman.gemspec
+++ b/puppetdb_foreman.gemspec
@@ -1,14 +1,21 @@
 require File.expand_path('../lib/puppetdb_foreman/version', __FILE__)
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'puppetdb_foreman'
   s.version     = PuppetdbForeman::VERSION
-  s.date        = '2015-10-25'
-  s.license     = 'GPL-3'
+  s.date        = Date.today.to_s
+  s.license     = 'GPL-3.0'
   s.summary     = 'This is a Foreman plugin to interact with PuppetDB.'
   s.description = 'Disable hosts on PuppetDB after they are deleted or built in Foreman, and proxy the PuppetDB dashboard to Foreman. Follow https://github.com/theforeman/puppetdb_foreman and raise an issue/submit a pull request if you need extra functionality. You can also find some help in #theforeman IRC channel on Freenode.'
-  s.authors     = ["Daniel Lobato Garcia"]
+  s.authors     = ['Daniel Lobato Garcia']
   s.email       = 'elobatocs@gmail.com'
-  s.files       = Dir['app/**/**'] + Dir['config/**/**'] + Dir['lib/**/**']
+  s.files       = Dir['{app,config,lib}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
+  s.test_files  = Dir['test/**/*']
   s.homepage    = 'http://www.github.com/theforeman/puppetdb_foreman'
+
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rdoc'
+  s.add_dependency 'webmock'
 end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1,0 +1,47 @@
+require 'test_plugin_helper'
+
+class HostTest < ActiveSupport::TestCase
+  setup do
+    User.current = FactoryGirl.build(:user, :admin)
+    setup_settings
+    disable_orchestration
+  end
+
+  context 'a host with puppetdb orchestration' do
+    let(:host) { FactoryGirl.build(:host, :managed) }
+
+    context 'with puppetdb enabled' do
+      before do
+        Setting[:puppetdb_enabled] = true
+      end
+
+      test 'should queue puppetdb destroy' do
+        assert_valid host
+        host.queue.clear
+        host.send(:queue_puppetdb_destroy)
+        tasks = host.queue.all.map(&:name)
+        assert_includes tasks, "Deactivating node #{host} in PuppetDB"
+        assert_equal 1, tasks.size
+      end
+
+      test '#delPuppetdb' do
+        ::PuppetdbClient::V3.any_instance.expects(:deactivate_node).with(host.name).returns(true)
+        host.send(:delPuppetdb)
+      end
+    end
+
+    context 'with puppetdb disabled' do
+      before do
+        Setting[:puppetdb_enabled] = false
+      end
+
+      test 'should not queue puppetdb destroy' do
+        assert_valid host
+        host.queue.clear
+        host.send(:queue_puppetdb_destroy)
+        tasks = host.queue.all.map(&:name)
+        assert_equal [], tasks
+      end
+    end
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,0 +1,23 @@
+# This calls the main test_helper in Foreman-core
+require 'test_helper'
+require 'database_cleaner'
+require 'webmock/minitest'
+
+# Foreman's setup doesn't handle cleaning up for Minitest::Spec
+DatabaseCleaner.strategy = :transaction
+
+def setup_settings
+  Setting::Puppetdb.load_defaults
+end
+
+module Minitest
+  class Spec
+    before :each do
+      DatabaseCleaner.start
+    end
+
+    after :each do
+      DatabaseCleaner.clean
+    end
+  end
+end

--- a/test/unit/puppetdb_test.rb
+++ b/test/unit/puppetdb_test.rb
@@ -1,0 +1,41 @@
+require 'test_plugin_helper'
+
+class PuppetdbTest < ActiveSupport::TestCase
+  setup do
+    User.current = FactoryGirl.build(:user, :admin)
+    setup_settings
+    disable_orchestration
+  end
+
+  let(:client) { Puppetdb.client }
+
+  context 'with V1 API' do
+    setup do
+      Setting[:puppetdb_address] = 'https://localhost:8080/v3/commands'
+    end
+
+    test 'deactivate_node' do
+      stub_request(:post, 'https://localhost:8080/v3/commands')
+        .with(:body => 'payload={"command":"deactivate node","version":1,"payload":"\\"www.example.com\\""}',
+              :headers => { 'Accept' => 'application/json' })
+        .to_return(:status => 200, :body => "{\"uuid\" : \"#{SecureRandom.uuid}\"}", :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+
+      assert_equal true, client.deactivate_node('www.example.com')
+    end
+  end
+
+  context 'with V3 API' do
+    let(:producer_timestamp) { Time.now.iso8601.to_s }
+
+    test 'deactivate_node' do
+      client.stubs(:producer_timestamp).returns(producer_timestamp)
+
+      stub_request(:post, 'https://puppetdb:8081/pdb/cmd/v1')
+        .with(:body => "{\"command\":\"deactivate node\",\"version\":3,\"payload\":{\"certname\":\"www.example.com\",\"producer_timestamp\":\"#{producer_timestamp}\"}}",
+              :headers => { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
+        .to_return(:status => 200, :body => "{\"uuid\" : \"#{SecureRandom.uuid}\"}", :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+
+      assert_equal true, client.deactivate_node('www.example.com')
+    end
+  end
+end


### PR DESCRIPTION
This PR moves the before_destroy to a the host queue, adds tests and PuppetDB Client code to use inheritance. It also fixes #28 and #30.