### PR TITLE
Add dashboard data url to the route to proxy to puppetdb

### DIFF
--- a/app/controllers/puppetdb_foreman/puppetdb_controller.rb
+++ b/app/controllers/puppetdb_foreman/puppetdb_controller.rb
@@ -8,7 +8,7 @@ module PuppetdbForeman
         uri = URI.parse(Setting[:puppetdb_dashboard_address])
         puppetdb_url, layout = case params[:puppetdb]
                                when 'd3.v2', 'charts'                                                    then ["#{uri.path}#{request.original_fullpath}", false]
-                               when 'v3', 'metrics', 'pdb/meta/v1/version', 'pdb/meta/v1/version/latest' then [request.original_fullpath, false]
+                               when 'v3', 'metrics', 'pdb/meta/v1/version', 'pdb/meta/v1/version/latest','pdb/dashboard/data' then [request.original_fullpath, false]
                                else                                                                      ["#{uri.path}/index.html", true]
                                end
         result = Net::HTTP.get_response(uri.host, puppetdb_url, uri.port)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  get ':puppetdb(/*puppetdb_url)', :to => 'puppetdb_foreman/puppetdb#index', :puppetdb => /d3\.v2|charts|v3|puppetdb|metrics|\/pdb\/meta\/v1\/version\/latest|pdb\/meta\/v1\/version/, :as => "puppetdb"
+  get ':puppetdb(/*puppetdb_url)', :to => 'puppetdb_foreman/puppetdb#index', :puppetdb => /d3\.v2|charts|v3|puppetdb|metrics|\/pdb\/meta\/v1\/version\/latest|pdb\/meta\/v1\/version|pdb\/dashboard\/data/, :as => "puppetdb"
 end


### PR DESCRIPTION
I was getting 404 errors on foreman, that nothing could handle GET requests for /pdb/dashboard/data. This is the url the puppetdb dashboard hits for data.

This commit adds the /pdb/dashboard/data url to the routes for this module, and forwards the request to puppetdb along with the other /pdb calls.

It may be cleaner to just add /pdb to the routes as they all seem to be handled the same way, but as I'm not sure why it's not there already, I wasn't comfortable with any side effects from that change