### PR TITLE
add puppetdb nodes controller

### DIFF
--- a/app/controllers/puppetdb_foreman/nodes_controller.rb
+++ b/app/controllers/puppetdb_foreman/nodes_controller.rb
@@ -1,0 +1,28 @@
+module PuppetdbForeman
+  class NodesController < ApplicationController
+    before_action :find_node, :only => [:destroy]
+
+    def controller_permission
+      'puppetdb_nodes'
+    end
+
+    def index
+      @foreman_hosts = Host.unscoped.pluck(:name)
+      @puppetdb_hosts = Puppetdb.client.query_nodes
+      @unknown_hosts = @puppetdb_hosts - @foreman_hosts
+    end
+
+    def destroy
+      Puppetdb.client.deactivate_node(@node)
+      process_success :success_msg => _('Deactivated node %s in PuppetDB') % (@node), :success_redirect => puppetdb_foreman_nodes_path
+    rescue => e
+      process_error(:redirect => puppetdb_foreman_nodes_path, :error_msg => _('Failed to deactivate node in PuppetDB: %s') % e.message)
+    end
+
+    private
+
+    def find_node
+      @node = params[:id]
+    end
+  end
+end

--- a/app/models/setting/puppetdb.rb
+++ b/app/models/setting/puppetdb.rb
@@ -1,7 +1,10 @@
 class Setting::Puppetdb < ::Setting
   BLANK_ATTRS << 'puppetdb_address'
+  BLANK_ATTRS << 'puppetdb_ssl_ca_file'
+  BLANK_ATTRS << 'puppetdb_ssl_certificate'
+  BLANK_ATTRS << 'puppetdb_ssl_private_key'
 
-  def self.load_defaults
+  def self.default_settings
     if SETTINGS[:puppetdb].present?
       default_enabled = SETTINGS[:puppetdb][:enabled]
       default_address = SETTINGS[:puppetdb][:address]
@@ -18,40 +21,28 @@ class Setting::Puppetdb < ::Setting
     default_ssl_certificate ||= "#{SETTINGS[:ssl_certificate]}"
     default_ssl_private_key ||= "#{SETTINGS[:ssl_priv_key]}"
 
-    Setting.transaction do
-      [
-        self.set('puppetdb_enabled', _("Integration with PuppetDB, enabled will deactivate a host in PuppetDB when it's deleted in Foreman"), default_enabled)
-      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
+    [
+      self.set('puppetdb_enabled', _("Integration with PuppetDB, enabled will deactivate a host in PuppetDB when it's deleted in Foreman"), default_enabled),
+      self.set('puppetdb_address', _('Foreman will send PuppetDB requests to this address'), default_address),
+      self.set('puppetdb_dashboard_address', _('Foreman will proxy PuppetDB Performance Dashboard requests to this address'), default_dashboard_address),
+      self.set('puppetdb_ssl_ca_file', _('Foreman will send PuppetDB requests with this CA file'), default_ssl_ca_file),
+      self.set('puppetdb_ssl_certificate', _('Foreman will send PuppetDB requests with this certificate file'), default_ssl_certificate),
+      self.set('puppetdb_ssl_private_key', _('Foreman will send PuppetDB requests with this key file'), default_ssl_private_key)
+    ]
+  end
+
+  def self.load_defaults
+    # Check the table exists
+    return unless super
+
+    self.transaction do
+      default_settings.each { |s| self.create! s.update(:category => "Setting::Puppetdb")}
     end
 
-    Setting.transaction do
-      [
-        self.set('puppetdb_address', _('Foreman will send PuppetDB requests to this address'), default_address)
-      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
-    end
+    true
+  end
 
-    Setting.transaction do
-      [
-        self.set('puppetdb_dashboard_address', _('Foreman will proxy PuppetDB Performance Dashboard requests to this address'), default_dashboard_address)
-      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
-    end
-
-    Setting.transaction do
-      [
-        self.set('puppetdb_ssl_ca_file', _('Foreman will send PuppetDB requests with this CA file'), default_ssl_ca_file)
-      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
-    end
-
-    Setting.transaction do
-      [
-        self.set('puppetdb_ssl_certificate', _('Foreman will send PuppetDB requests with this certificate file'), default_ssl_certificate)
-      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
-    end
-
-    Setting.transaction do
-      [
-        self.set('puppetdb_ssl_private_key', _('Foreman will send PuppetDB requests with this key file'), default_ssl_private_key)
-      ].compact.each { |s| self.create s.update(:category => 'Setting::Puppetdb')}
-    end
+  def self.humanized_category
+    N_('PuppetDB')
   end
 end

--- a/app/services/puppetdb_client/v1.rb
+++ b/app/services/puppetdb_client/v1.rb
@@ -9,5 +9,13 @@ module PuppetdbClient
       }.to_json
       'payload=' + payload
     end
+
+    def command_url
+      '/v3/commands'
+    end
+
+    def nodes_url
+      '/v3/nodes'
+    end
   end
 end

--- a/app/services/puppetdb_client/v3.rb
+++ b/app/services/puppetdb_client/v3.rb
@@ -20,6 +20,14 @@ module PuppetdbClient
       }.to_json
     end
 
+    def command_url
+      '/pdb/cmd/v1'
+    end
+
+    def nodes_url
+      '/pdb/query/v4/nodes'
+    end
+
     private
 
     def producer_timestamp

--- a/app/views/puppetdb_foreman/nodes/index.html.erb
+++ b/app/views/puppetdb_foreman/nodes/index.html.erb
@@ -1,0 +1,59 @@
+<% title _('PuppetDB Nodes') %>
+
+<div class="col-md-12">
+  <div class="row">
+    <div class="container-fluid container-cards-pf">
+      <div class="row row-cards-pf">
+        <div class="col-xs-6 col-sm-4 col-md-4">
+          <div class="card-pf card-pf-accented card-pf-aggregate-status">
+            <h2 class="card-pf-title">
+              <span class="fa fa-database"></span><span class="card-pf-aggregate-status-count"><%= @puppetdb_hosts.count %></span> <%= _('Hosts in PuppetDB') %>
+            </h2>
+            <div class="card-pf-body">
+              <p class="card-pf-aggregate-status-notifications">
+              <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="col-xs-6 col-sm-4 col-md-4">
+          <div class="card-pf card-pf-accented card-pf-aggregate-status">
+            <h2 class="card-pf-title">
+              <span class="pficon pficon-server"></span><span class="card-pf-aggregate-status-count"><%= @foreman_hosts.count %></span> <%= _('Hosts in Foreman') %>
+            </h2>
+            <div class="card-pf-body">
+              <p class="card-pf-aggregate-status-notifications">
+              <span class="card-pf-aggregate-status-notification"><span class="pficon pficon-ok"></span></span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <h2><%= _('Hosts unknown to Foreman') %></h2>
+    </div>
+    <div class="row">
+      <table class="<%= table_css_classes 'table-fixed' %>">
+        <thead>
+          <tr>
+            <th><%= _('Name') %></th>
+            <th class="col-md-1"><%= _('Actions') %></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @unknown_hosts.each do |node| %>
+            <tr>
+              <td class="ellipsis"><%= node %></td>
+              <td>
+                <%= action_buttons(
+                  (display_delete_if_authorized(hash_for_puppetdb_foreman_node_path(:id => node), :class => 'delete', :text => _('Deactivate')))
+                ) %>
+            </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   get ':puppetdb(/*puppetdb_url)', :to => 'puppetdb_foreman/puppetdb#index', :puppetdb => /d3\.v2|charts|v3|puppetdb|metrics|\/pdb\/meta\/v1\/version\/latest|pdb\/meta\/v1\/version|pdb\/dashboard\/data/, :as => "puppetdb"
+
+  namespace :puppetdb_foreman do
+    constraints(:id => %r{[^\/]+}) do
+      resources :nodes, :only => [:index, :destroy]
+    end
+  end
 end

--- a/lib/puppetdb_foreman/engine.rb
+++ b/lib/puppetdb_foreman/engine.rb
@@ -15,17 +15,29 @@ module PuppetdbForeman
         requires_foreman '>= 1.11'
         security_block :puppetdb_foreman do
           permission :view_puppetdb_dashboard, :'puppetdb_foreman/puppetdb' => [:index]
+          permission :view_puppetdb_nodes, :'puppetdb_foreman/nodes' => [:index]
+          permission :destroy_puppetdb_nodes, :'puppetdb_foreman/nodes' => [:destroy]
         end
         role 'PuppetDB Dashboard', [:view_puppetdb_dashboard]
+        role 'PuppetDB Node Viewer', [:view_puppetdb_nodes]
+        role 'PuppetDB Node Manager', [:view_puppetdb_nodes, :destroy_puppetdb_nodes]
         menu :top_menu, :puppetdb, :caption => N_('PuppetDB Dashboard'),
                                    :url_hash => { :controller => 'puppetdb_foreman/puppetdb', :action => 'index', :puppetdb => 'puppetdb' },
                                    :parent => :monitor_menu,
-                                   :last => true
+                                   :last => :true
+        menu :top_menu, :nodes, :caption => N_('PuppetDB Nodes'),
+                                   :url_hash => { :controller => 'puppetdb_foreman/nodes', :action => 'index' },
+                                   :parent => :monitor_menu,
+                                   :after => :puppetdb
       end
     end
 
     config.to_prepare do
-      Host::Managed.send :include, PuppetdbForeman::HostExtensions
+      begin
+        Host::Managed.send :include, PuppetdbForeman::HostExtensions
+      rescue => e
+        Rails.logger.warn "PuppetdbForeman: skipping engine hook (#{e})"
+      end
     end
   end
 end

--- a/test/controllers/nodes_controller_test.rb
+++ b/test/controllers/nodes_controller_test.rb
@@ -1,0 +1,37 @@
+require 'test_plugin_helper'
+
+class NodesControllerTest < ActionController::TestCase
+  tests ::PuppetdbForeman::NodesController
+
+  setup do
+    setup_settings
+    User.current = users(:admin)
+    @host = FactoryGirl.create(:host, :managed)
+  end
+
+  context '#index' do
+    test 'lists puppetdb nodes unknown to foreman' do
+      host = FactoryGirl.create(:host, :managed)
+      ::PuppetdbClient::V3.any_instance.stubs(:query_nodes).returns([host.name, 'two.example.com'])
+      get :index, {}, set_session_user
+      assert_response :success
+      refute response.body =~ /#{host.name}/m
+      assert response.body =~ /two.example.com/m
+    end
+  end
+
+  context '#destroy' do
+    let(:node) { 'test.example.com' }
+    test 'deactivating a node in puppetdb' do
+      ::PuppetdbClient::V3.any_instance.expects(:deactivate_node).with(node).returns(true)
+      delete :destroy, {
+        :id => node,
+      }, set_session_user
+      assert_response :found
+      assert_redirected_to puppetdb_foreman_nodes_path
+      assert_nil flash[:error]
+      assert_not_nil flash[:notice]
+      assert_equal "Deactivated node #{node} in PuppetDB", flash[:notice]
+    end
+  end
+end

--- a/test/static_fixtures/query_nodes.json
+++ b/test/static_fixtures/query_nodes.json
@@ -1,0 +1,61 @@
+[ {
+  "name" : "server1.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:07:27.114Z",
+  "facts_timestamp" : "2017-04-20T15:06:52.738Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server2.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:06:28.282Z",
+  "facts_timestamp" : "2017-04-20T15:06:12.253Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server3.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:12:56.090Z",
+  "facts_timestamp" : "2017-04-20T15:12:32.117Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server4.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:04:01.154Z",
+  "facts_timestamp" : "2017-04-20T15:03:38.150Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server5.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:20:06.853Z",
+  "facts_timestamp" : "2017-04-20T15:19:49.088Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server6.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:21:11.520Z",
+  "facts_timestamp" : "2017-04-20T15:20:57.685Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server7.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:15:37.033Z",
+  "facts_timestamp" : "2017-04-20T15:15:13.918Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server8.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:19:18.236Z",
+  "facts_timestamp" : "2017-04-20T15:19:02.659Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server9.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T14:39:35.070Z",
+  "facts_timestamp" : "2017-04-20T14:39:19.003Z",
+  "report_timestamp" : null
+}, {
+  "name" : "server10.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:17:06.209Z",
+  "facts_timestamp" : "2017-04-20T15:16:50.007Z",
+  "report_timestamp" : null
+} ]

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -10,6 +10,10 @@ def setup_settings
   Setting::Puppetdb.load_defaults
 end
 
+def fixture(name)
+  File.read(File.expand_path("../static_fixtures/#{name}", __FILE__))
+end
+
 module Minitest
   class Spec
     before :each do

--- a/test/unit/puppetdb_test.rb
+++ b/test/unit/puppetdb_test.rb
@@ -22,6 +22,14 @@ class PuppetdbTest < ActiveSupport::TestCase
 
       assert_equal true, client.deactivate_node('www.example.com')
     end
+
+    test 'query_nodes' do
+      stub_request(:get, 'https://localhost:8080/v3/nodes')
+        .with(:headers => { 'Accept' => 'application/json' })
+        .to_return(:status => 200, :body => fixture('query_nodes.json'), :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+      expected = (1..10).map {|i| "server#{i}.example.com"}
+      assert_equal expected, client.query_nodes
+    end
   end
 
   context 'with V3 API' do
@@ -36,6 +44,14 @@ class PuppetdbTest < ActiveSupport::TestCase
         .to_return(:status => 200, :body => "{\"uuid\" : \"#{SecureRandom.uuid}\"}", :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
 
       assert_equal true, client.deactivate_node('www.example.com')
+    end
+
+    test 'query_nodes' do
+      stub_request(:get, 'https://puppetdb:8081/pdb/query/v4/nodes')
+        .with(:headers => { 'Accept' => 'application/json' })
+        .to_return(:status => 200, :body => fixture('query_nodes.json'), :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+      expected = (1..10).map {|i| "server#{i}.example.com"}
+      assert_equal expected, client.query_nodes
     end
   end
 end


### PR DESCRIPTION
This requires #31.

Sometimes you get stale hosts in puppetdb. This PR diffs them against the hosts known in Foreman and allows a user do deactivate them:

![image](https://cloud.githubusercontent.com/assets/4107560/25279338/6959fb90-26a6-11e7-859d-320a56e418fd.png)

