### PR TITLE
Add support for PuppetDB API v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ for PuppetDB 4
   :puppetdb_ssl_ca_file: '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
   :puppetdb_ssl_certificate: '/etc/puppetlabs/puppet/ssl/certs/FQDN.pem'
   :puppetdb_ssl_private_key: '/etc/puppetlabs/puppet/ssl/private_keys/FQDN.pem'
+  :puppetdb_api_version: 4
 ```
 
 You can find the dashboard under Monitor > PuppetDB dashboard. Only administrators and users with a role `view_puppetdb_dashboard` will be able to access it. Aside from convenience, the PuppetDB dashboard cannot be served over HTTPS, you can restrict your dashboard requests to only Foreman boxes and serve it securely to your users through HTTPS in Foreman.

--- a/app/models/setting/puppetdb.rb
+++ b/app/models/setting/puppetdb.rb
@@ -31,7 +31,7 @@ class Setting::Puppetdb < ::Setting
       set('puppetdb_ssl_ca_file', _('Foreman will send PuppetDB requests with this CA file'), default_ssl_ca_file),
       set('puppetdb_ssl_certificate', _('Foreman will send PuppetDB requests with this certificate file'), default_ssl_certificate),
       set('puppetdb_ssl_private_key', _('Foreman will send PuppetDB requests with this key file'), default_ssl_private_key),
-      set('puppetdb_api_version', _('Foreman will use this PuppetDB API version'), default_api_version)
+      set('puppetdb_api_version', _('Foreman will use this PuppetDB API version'), 'delete', N_('PuppetDB API Version'), nil, { collection: Proc.new { ::PuppetDB::API_VERSIONS }})
     ]
   end
 

--- a/app/models/setting/puppetdb.rb
+++ b/app/models/setting/puppetdb.rb
@@ -3,6 +3,7 @@ class Setting::Puppetdb < ::Setting
   BLANK_ATTRS << 'puppetdb_ssl_ca_file'
   BLANK_ATTRS << 'puppetdb_ssl_certificate'
   BLANK_ATTRS << 'puppetdb_ssl_private_key'
+  BLANK_ATTRS << 'puppetdb_api_version'
 
   def self.default_settings
     if SETTINGS[:puppetdb].present?
@@ -12,6 +13,7 @@ class Setting::Puppetdb < ::Setting
       default_ssl_ca_file = SETTINGS[:puppetdb][:ssl_ca_file]
       default_ssl_certificate = SETTINGS[:puppetdb][:ssl_certificate]
       default_ssl_private_key = SETTINGS[:puppetdb][:ssl_private_key]
+      default_api_version = SETTINGS[:puppetdb][:api_version]
     end
 
     default_enabled = false if default_enabled.nil?
@@ -20,6 +22,7 @@ class Setting::Puppetdb < ::Setting
     default_ssl_ca_file ||= (SETTINGS[:ssl_ca_file]).to_s
     default_ssl_certificate ||= (SETTINGS[:ssl_certificate]).to_s
     default_ssl_private_key ||= (SETTINGS[:ssl_priv_key]).to_s
+    default_api_version ||= 4
 
     [
       set('puppetdb_enabled', _("Integration with PuppetDB, enabled will deactivate a host in PuppetDB when it's deleted in Foreman"), default_enabled),
@@ -27,7 +30,8 @@ class Setting::Puppetdb < ::Setting
       set('puppetdb_dashboard_address', _('Foreman will proxy PuppetDB Performance Dashboard requests to this address'), default_dashboard_address),
       set('puppetdb_ssl_ca_file', _('Foreman will send PuppetDB requests with this CA file'), default_ssl_ca_file),
       set('puppetdb_ssl_certificate', _('Foreman will send PuppetDB requests with this certificate file'), default_ssl_certificate),
-      set('puppetdb_ssl_private_key', _('Foreman will send PuppetDB requests with this key file'), default_ssl_private_key)
+      set('puppetdb_ssl_private_key', _('Foreman will send PuppetDB requests with this key file'), default_ssl_private_key),
+      set('puppetdb_api_version', _('Foreman will use this PuppetDB API version'), default_api_version)
     ]
   end
 

--- a/app/services/puppetdb.rb
+++ b/app/services/puppetdb.rb
@@ -1,4 +1,7 @@
 module Puppetdb
+
+  class UnsupportedVersion < StandardError; end
+
   def self.client
     options = {
       :uri => uri,
@@ -6,10 +9,18 @@ module Puppetdb
       :ssl_certificate_file => Setting[:puppetdb_ssl_certificate],
       :ssl_private_key_file => Setting[:puppetdb_ssl_private_key]
     }
-    if uri.path.start_with?('/pdb')
-      PuppetdbClient::V3.new(options)
-    else
+
+    api_version = Setting[:puppetdb_api_version].to_i
+
+    case api_version
+    when 1
       PuppetdbClient::V1.new(options)
+    when 3
+      PuppetdbClient::V3.new(options)
+    when 4
+      PuppetdbClient::V4.new(options)
+    else
+      raise ::Puppetdb::UnsupportedVersion
     end
   end
 

--- a/app/services/puppetdb.rb
+++ b/app/services/puppetdb.rb
@@ -1,6 +1,10 @@
 module Puppetdb
 
-  class UnsupportedVersion < StandardError; end
+  API_VERSIONS = {
+    '4' => 'v4: PuppetDB 2.3, 3.0, 3.1, 3.2, 4.0 (PE 3.8, 2015.2, 2015.3)',
+    '3' => 'v3: PuppetDB 1.5, 1.6 (PE 3.1, 3.2, 3.3)',
+    '2' => 'v2: PuppetDB 1.1, 1.2, 1.3, 1.4'
+  }.freeze
 
   def self.client
     options = {
@@ -10,8 +14,6 @@ module Puppetdb
       :ssl_private_key_file => Setting[:puppetdb_ssl_private_key]
     }
 
-    api_version = Setting[:puppetdb_api_version].to_i
-
     case api_version
     when 1
       PuppetdbClient::V1.new(options)
@@ -20,8 +22,12 @@ module Puppetdb
     when 4
       PuppetdbClient::V4.new(options)
     else
-      raise ::Puppetdb::UnsupportedVersion
+      raise Foreman::Exception.new(N_('Unsupported PuppetDB version.'))
     end
+  end
+
+  def self.api_version
+    Setting[:puppetdb_api_version].to_i
   end
 
   def self.uri

--- a/app/services/puppetdb_client/base.rb
+++ b/app/services/puppetdb_client/base.rb
@@ -18,8 +18,7 @@ module PuppetdbClient
     end
 
     def query_nodes
-      nodes = parse(get(nodes_url))
-      nodes.map { |node| node['name'] }
+      parse(get(nodes_url))
     end
 
     def facts(nodename)

--- a/app/services/puppetdb_client/v1.rb
+++ b/app/services/puppetdb_client/v1.rb
@@ -21,5 +21,9 @@ module PuppetdbClient
     def facts_url
       '/v3/facts'
     end
+
+    def query_nodes
+      super.map { |node| node['name'] }
+    end
   end
 end

--- a/app/services/puppetdb_client/v3.rb
+++ b/app/services/puppetdb_client/v3.rb
@@ -26,6 +26,10 @@ module PuppetdbClient
       '/pdb/query/v4/facts'
     end
 
+    def query_nodes
+      super.map { |node| node['certname'] }
+    end
+
     private
 
     def post_options

--- a/app/services/puppetdb_client/v4.rb
+++ b/app/services/puppetdb_client/v4.rb
@@ -1,0 +1,4 @@
+module PuppetdbClient
+  class V4 < V3
+  end
+end

--- a/app/services/puppetdb_host.rb
+++ b/app/services/puppetdb_host.rb
@@ -26,7 +26,7 @@ class PuppetdbHost
   end
 
   def parse_fact_value(value)
-    result = JSON.parse(value)
+    result = value.is_a?(String) ? JSON.parse(value) : value
     return result.to_s unless result.is_a?(Hash)
     deep_stringify_values(result)
   rescue JSON::ParserError

--- a/test/controllers/api/v2/puppetdb_nodes_controller_test.rb
+++ b/test/controllers/api/v2/puppetdb_nodes_controller_test.rb
@@ -9,7 +9,7 @@ class Api::V2::PuppetdbNodesControllerTest < ActionController::TestCase
 
   context '#index' do
     test 'lists puppetdb nodes unknown to foreman' do
-      ::PuppetdbClient::V3.any_instance.stubs(:query_nodes).returns(['one.example.com', 'two.example.com'])
+      ::PuppetdbClient::V4.any_instance.stubs(:query_nodes).returns(['one.example.com', 'two.example.com'])
       get :index, {}, set_session_user
       assert_response :success
       response = ActiveSupport::JSON.decode(@response.body)
@@ -22,7 +22,7 @@ class Api::V2::PuppetdbNodesControllerTest < ActionController::TestCase
   context '#unknown' do
     test 'lists puppetdb nodes unknown to foreman' do
       host = FactoryGirl.create(:host, :managed)
-      ::PuppetdbClient::V3.any_instance.stubs(:query_nodes).returns([host.name, 'two.example.com'])
+      ::PuppetdbClient::V4.any_instance.stubs(:query_nodes).returns([host.name, 'two.example.com'])
       get :unknown, {}, set_session_user
       assert_response :success
       response = ActiveSupport::JSON.decode(@response.body)
@@ -37,7 +37,7 @@ class Api::V2::PuppetdbNodesControllerTest < ActionController::TestCase
     let(:uuid) { SecureRandom.uuid }
 
     before do
-      ::PuppetdbClient::V3.any_instance.expects(:deactivate_node).with(node).returns(uuid)
+      ::PuppetdbClient::V4.any_instance.expects(:deactivate_node).with(node).returns(uuid)
     end
 
     test 'imports a host by puppetdb facts' do
@@ -54,7 +54,7 @@ class Api::V2::PuppetdbNodesControllerTest < ActionController::TestCase
     let(:host) { FactoryGirl.create(:host) }
 
     before do
-      ::PuppetdbClient::V3.any_instance.expects(:facts).with(node).returns({})
+      ::PuppetdbClient::V4.any_instance.expects(:facts).with(node).returns({})
       PuppetdbHost.any_instance.expects(:to_host).returns(host)
     end
 

--- a/test/controllers/nodes_controller_test.rb
+++ b/test/controllers/nodes_controller_test.rb
@@ -12,7 +12,7 @@ class NodesControllerTest < ActionController::TestCase
   context '#index' do
     test 'lists puppetdb nodes unknown to foreman' do
       host = FactoryGirl.create(:host, :managed)
-      ::PuppetdbClient::V3.any_instance.stubs(:query_nodes).returns([host.name, 'two.example.com'])
+      ::PuppetdbClient::V4.any_instance.stubs(:query_nodes).returns([host.name, 'two.example.com'])
       get :index, {}, set_session_user
       assert_response :success
       refute response.body =~ /#{host.name}/m
@@ -23,7 +23,7 @@ class NodesControllerTest < ActionController::TestCase
   context '#destroy' do
     let(:node) { 'test.example.com' }
     test 'deactivating a node in puppetdb' do
-      ::PuppetdbClient::V3.any_instance.expects(:deactivate_node).with(node).returns(true)
+      ::PuppetdbClient::V4.any_instance.expects(:deactivate_node).with(node).returns(true)
       delete :destroy, { :id => node }, set_session_user
       assert_response :found
       assert_redirected_to puppetdb_foreman_nodes_path
@@ -38,7 +38,7 @@ class NodesControllerTest < ActionController::TestCase
     let(:host) { FactoryGirl.create(:host) }
 
     before do
-      ::PuppetdbClient::V3.any_instance.expects(:facts).with(node).returns({})
+      ::PuppetdbClient::V4.any_instance.expects(:facts).with(node).returns({})
       PuppetdbHost.any_instance.expects(:to_host).returns(host)
     end
 

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -25,7 +25,7 @@ class HostTest < ActiveSupport::TestCase
       end
 
       test '#delPuppetdb' do
-        ::PuppetdbClient::V3.any_instance.expects(:deactivate_node).with(host.name).returns(true)
+        ::PuppetdbClient::V4.any_instance.expects(:deactivate_node).with(host.name).returns(true)
         host.send(:delPuppetdb)
       end
     end

--- a/test/static_fixtures/query_nodes_v3_4.json
+++ b/test/static_fixtures/query_nodes_v3_4.json
@@ -1,0 +1,61 @@
+[ {
+  "certname" : "server1.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:07:27.114Z",
+  "facts_timestamp" : "2017-04-20T15:06:52.738Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server2.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:06:28.282Z",
+  "facts_timestamp" : "2017-04-20T15:06:12.253Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server3.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:12:56.090Z",
+  "facts_timestamp" : "2017-04-20T15:12:32.117Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server4.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:04:01.154Z",
+  "facts_timestamp" : "2017-04-20T15:03:38.150Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server5.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:20:06.853Z",
+  "facts_timestamp" : "2017-04-20T15:19:49.088Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server6.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:21:11.520Z",
+  "facts_timestamp" : "2017-04-20T15:20:57.685Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server7.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:15:37.033Z",
+  "facts_timestamp" : "2017-04-20T15:15:13.918Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server8.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:19:18.236Z",
+  "facts_timestamp" : "2017-04-20T15:19:02.659Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server9.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T14:39:35.070Z",
+  "facts_timestamp" : "2017-04-20T14:39:19.003Z",
+  "report_timestamp" : null
+}, {
+  "certname" : "server10.example.com",
+  "deactivated" : null,
+  "catalog_timestamp" : "2017-04-20T15:17:06.209Z",
+  "facts_timestamp" : "2017-04-20T15:16:50.007Z",
+  "report_timestamp" : null
+} ]

--- a/test/unit/puppetdb_test.rb
+++ b/test/unit/puppetdb_test.rb
@@ -69,7 +69,7 @@ class PuppetdbTest < ActiveSupport::TestCase
     test 'query_nodes' do
       stub_request(:get, 'https://puppetdb:8081/pdb/query/v4/nodes')
         .with(:headers => { 'Accept' => 'application/json' })
-        .to_return(:status => 200, :body => fixture('query_nodes.json'), :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+        .to_return(:status => 200, :body => fixture('query_nodes_v3_4.json'), :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
       expected = (1..10).map { |i| "server#{i}.example.com" }
       assert_equal expected, client.query_nodes
     end
@@ -110,7 +110,7 @@ class PuppetdbTest < ActiveSupport::TestCase
     test 'query_nodes' do
       stub_request(:get, 'https://puppetdb:8081/pdb/query/v4/nodes')
         .with(:headers => { 'Accept' => 'application/json' })
-        .to_return(:status => 200, :body => fixture('query_nodes.json'), :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+        .to_return(:status => 200, :body => fixture('query_nodes_v3_4.json'), :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
       expected = (1..10).map { |i| "server#{i}.example.com" }
       assert_equal expected, client.query_nodes
     end

--- a/test/unit/puppetdb_test.rb
+++ b/test/unit/puppetdb_test.rb
@@ -12,6 +12,7 @@ class PuppetdbTest < ActiveSupport::TestCase
 
   context 'with V1 API' do
     setup do
+      Setting[:puppetdb_api_version] = 1
       Setting[:puppetdb_address] = 'https://localhost:8080/v3/commands'
     end
 
@@ -48,6 +49,10 @@ class PuppetdbTest < ActiveSupport::TestCase
   end
 
   context 'with V3 API' do
+    setup do
+      Setting[:puppetdb_api_version] = 3
+    end
+
     let(:producer_timestamp) { Time.now.iso8601.to_s }
 
     test 'deactivate_node' do
@@ -81,6 +86,59 @@ class PuppetdbTest < ActiveSupport::TestCase
         'certname' => 'host.example.com'
       }
       assert_includes facts, sample
+    end
+  end
+
+  context 'with V4 API' do
+    setup do
+      Setting[:puppetdb_api_version] = 4
+    end
+
+    let(:producer_timestamp) { Time.now.iso8601.to_s }
+
+    test 'deactivate_node' do
+      client.stubs(:producer_timestamp).returns(producer_timestamp)
+
+      stub_request(:post, 'https://puppetdb:8081/pdb/cmd/v1')
+        .with(:body => "{\"command\":\"deactivate node\",\"version\":3,\"payload\":{\"certname\":\"www.example.com\",\"producer_timestamp\":\"#{producer_timestamp}\"}}",
+              :headers => { 'Accept' => 'application/json', 'Content-Type' => 'application/json' })
+        .to_return(:status => 200, :body => "{\"uuid\" : \"#{uuid}\"}", :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+
+      assert_equal uuid, client.deactivate_node('www.example.com')
+    end
+
+    test 'query_nodes' do
+      stub_request(:get, 'https://puppetdb:8081/pdb/query/v4/nodes')
+        .with(:headers => { 'Accept' => 'application/json' })
+        .to_return(:status => 200, :body => fixture('query_nodes.json'), :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+      expected = (1..10).map { |i| "server#{i}.example.com" }
+      assert_equal expected, client.query_nodes
+    end
+
+    test 'facts' do
+      stub_request(:get, 'https://puppetdb:8081/pdb/query/v4/facts?query=%5B%22=%22,%20%22certname%22,%20%22host.example.com%22%5D')
+        .with(:headers => { 'Accept' => 'application/json' })
+        .to_return(:status => 200, :body => fixture('facts.json'), :headers => { 'Content-Type' => 'application/json; charset=utf-8' })
+      facts = client.facts('host.example.com')
+      assert_kind_of Array, facts
+      sample = {
+        'value' => 'CEST',
+        'name' => 'timezone',
+        'certname' => 'host.example.com'
+      }
+      assert_includes facts, sample
+    end
+  end
+
+  context 'when the puppetdb version is not supported' do
+    setup do
+      Setting[:puppetdb_api_version] = -10
+    end
+
+    test 'it raises error about unsupported version' do
+      assert_raises Puppetdb::UnsupportedVersion do
+        client
+      end
     end
   end
 end


### PR DESCRIPTION
- Fix finding nodes by using `certname` over `name` (v3, v4)
- Support non-string facts
- Add `:puppetdb_api_version` option instead of parsing the URI to guess the version