### PR TITLE
Fix the example for the settings.yaml file, for the SSL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ for PuppetDB 4
   :enabled: true
   :address: 'https://puppetdb:8081/pdb/cmd/v1'
   :dashboard_address: 'http://puppetdb:8080/pdb/dashboard'
-  :puppetdb_ssl_ca_file: '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
-  :puppetdb_ssl_certificate: '/etc/puppetlabs/puppet/ssl/certs/FQDN.pem'
-  :puppetdb_ssl_private_key: '/etc/puppetlabs/puppet/ssl/private_keys/FQDN.pem'
+  :ca_file: '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
+  :certificate: '/etc/puppetlabs/puppet/ssl/certs/FQDN.pem'
+  :private_key: '/etc/puppetlabs/puppet/ssl/private_keys/FQDN.pem'
 ```
 
 You can find the dashboard under Monitor > PuppetDB dashboard. Only administrators and users with a role `view_puppetdb_dashboard` will be able to access it. Aside from convenience, the PuppetDB dashboard cannot be served over HTTPS, you can restrict your dashboard requests to only Foreman boxes and serve it securely to your users through HTTPS in Foreman.


### PR DESCRIPTION
The example for configuring this module through the settings.yaml file shows the ssl parameters with 'puppetdb_' prefixes. This is incorrect, these settings should not have the 'puppetdb_' prefix.

This PR fixes this.