### PR TITLE
Use the certname rather than the hostname to delete

### DIFF
--- a/app/models/concerns/orchestration/puppetdb.rb
+++ b/app/models/concerns/orchestration/puppetdb.rb
@@ -20,11 +20,12 @@ module Orchestration
     end
 
     def del_puppetdb
-      Rails.logger.info "Deactivating node in PuppetDB: #{name}"
-      ::Puppetdb.client.deactivate_node(name)
+      Rails.logger.info "Deactivating node in PuppetDB: #{certname} (#{name})"
+      ::Puppetdb.client.deactivate_node(certname)
     rescue StandardError => e
       failure format(
-        _("Failed to deactivate node %<name>s in PuppetDB: %<message>s\n "), name: name, message: e.message
+        _("Failed to deactivate node %<certname> (%<name>) in PuppetDB: %<message>\n "),
+        name: name, message: e.message, certname: certname
       ), e
     end
 

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -26,7 +26,7 @@ class HostTest < ActiveSupport::TestCase
       end
 
       test '#del_puppetdb' do
-        ::PuppetdbClient::V4.any_instance.expects(:deactivate_node).with(host.name).returns(true)
+        ::PuppetdbClient::V4.any_instance.expects(:deactivate_node).with(host.certname).returns(true)
         host.send(:del_puppetdb)
       end
     end


### PR DESCRIPTION
The deactivate node requires the certname. In Foreman we track this separately.

https://puppet.com/docs/puppetdb/6.4/api/command/v1/commands.html#deactivate-node-version-3

Note I haven't tested this.