### PR TITLE
Fixes #28991 - Add description to plugin roles

### DIFF
--- a/lib/puppetdb_foreman/engine.rb
+++ b/lib/puppetdb_foreman/engine.rb
@@ -35,7 +35,7 @@ module PuppetdbForeman
 
         role 'PuppetDB Node Viewer', [:view_puppetdb_nodes], 'Role granting permissions to view nodes from PuppetDB.'
         role 'PuppetDB Node Manager', [:view_puppetdb_nodes, :destroy_puppetdb_nodes, :import_puppetdb_nodes], 
-             'Role granting permissions to manage Puppet nodes.'
+             'Role granting permissions to manage nodes from PuppetDB.'
 
         menu :top_menu, :nodes, :caption => N_('PuppetDB Nodes'),
                                 :url_hash => { :controller => 'puppetdb_foreman/nodes', :action => 'index' },

--- a/lib/puppetdb_foreman/engine.rb
+++ b/lib/puppetdb_foreman/engine.rb
@@ -33,8 +33,8 @@ module PuppetdbForeman
                                              :'api/v2/puppetdb_nodes' => [:import]
         end
 
-        role 'PuppetDB Node Viewer', [:view_puppetdb_nodes]
-        role 'PuppetDB Node Manager', [:view_puppetdb_nodes, :destroy_puppetdb_nodes, :import_puppetdb_nodes]
+        role 'PuppetDB Node Viewer', [:view_puppetdb_nodes], 'TODO: Description'
+        role 'PuppetDB Node Manager', [:view_puppetdb_nodes, :destroy_puppetdb_nodes, :import_puppetdb_nodes], 'TODO: Description'
 
         menu :top_menu, :nodes, :caption => N_('PuppetDB Nodes'),
                                 :url_hash => { :controller => 'puppetdb_foreman/nodes', :action => 'index' },

--- a/lib/puppetdb_foreman/engine.rb
+++ b/lib/puppetdb_foreman/engine.rb
@@ -33,7 +33,7 @@ module PuppetdbForeman
                                              :'api/v2/puppetdb_nodes' => [:import]
         end
 
-        role 'PuppetDB Node Viewer', [:view_puppetdb_nodes], 'Role granting permissions to view Puppet nodes.'
+        role 'PuppetDB Node Viewer', [:view_puppetdb_nodes], 'Role granting permissions to view nodes from PuppetDB.'
         role 'PuppetDB Node Manager', [:view_puppetdb_nodes, :destroy_puppetdb_nodes, :import_puppetdb_nodes], 
              'Role granting permissions to manage Puppet nodes.'
 

--- a/lib/puppetdb_foreman/engine.rb
+++ b/lib/puppetdb_foreman/engine.rb
@@ -33,8 +33,9 @@ module PuppetdbForeman
                                              :'api/v2/puppetdb_nodes' => [:import]
         end
 
-        role 'PuppetDB Node Viewer', [:view_puppetdb_nodes], 'TODO: Description'
-        role 'PuppetDB Node Manager', [:view_puppetdb_nodes, :destroy_puppetdb_nodes, :import_puppetdb_nodes], 'TODO: Description'
+        role 'PuppetDB Node Viewer', [:view_puppetdb_nodes], 'Role granting permissions to view Puppet nodes.'
+        role 'PuppetDB Node Manager', [:view_puppetdb_nodes, :destroy_puppetdb_nodes, :import_puppetdb_nodes], 
+             'Role granting permissions to manage Puppet nodes.'
 
         menu :top_menu, :nodes, :caption => N_('PuppetDB Nodes'),
                                 :url_hash => { :controller => 'puppetdb_foreman/nodes', :action => 'index' },


### PR DESCRIPTION
PR is part of  [Add default descriptions to all roles added from plugins](https://projects.theforeman.org/issues/28936) task.