### PR TITLE
Add shared GitHub Actions workflow for ruby testing

### DIFF
--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+      - '*-stable'
+
+concurrency:
+  group: ${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  rubocop:
+    name: Rubocop
+    uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+    with:
+        command: bundle exec rubocop --parallel --format github
+
+  test:
+    name: Ruby
+    needs: rubocop
+    uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
+    with:
+      plugin: puppetdb_foreman


### PR DESCRIPTION
Updating the GitHub Action workflow by using shared rubocop and foreman plugin test action:
https://github.com/theforeman/actions#rubocop
https://github.com/theforeman/actions#foreman-plugin-tests