### PR TITLE
Document PuppetDB v8 compatibility

### DIFF
--- a/app/services/puppetdb.rb
+++ b/app/services/puppetdb.rb
@@ -2,7 +2,7 @@
 
 module Puppetdb
   API_VERSIONS = {
-    '4' => 'v4: PuppetDB 4 - 7',
+    '4' => 'v4: PuppetDB 4 - 8',
   }.freeze
 
   def self.client # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Since some years, PuppetDB version 8 is around and Foreman installs it. The API version didn't change, it's still v4.